### PR TITLE
Add battery swap time analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Este repositorio contiene utilidades para simulación.
 
+## Gráfico de tiempo de intercambio
+
+Ejecuta el script `tiempos_intercambio.py` para generar un gráfico con el tiempo
+promedio que tarda en completarse el intercambio de baterías en función del
+número de autobuses simulados:
+
+```bash
+python tiempos_intercambio.py
+```
+
+Se abrirá una ventana con la gráfica correspondiente.
+
 ## Ejecutar las pruebas
 
 Instala `pytest` y ejecuta las pruebas con:

--- a/tiempos_intercambio.py
+++ b/tiempos_intercambio.py
@@ -1,0 +1,35 @@
+import matplotlib.pyplot as plt
+
+import modelo
+
+from modelo import param_simulacion
+
+TIEMPO_REEMPLAZO = 0.083  # Tiempo fijo del intercambio en horas
+
+def tiempo_promedio_para_autobuses(numero_autobuses):
+    """Ejecuta la simulación para cierto número de autobuses y devuelve
+    el tiempo promedio de intercambio."""
+    # Desactivar la verbosidad durante las simulaciones
+    anterior = modelo.VERBOSE
+    modelo.VERBOSE = False
+    estacion = modelo.ejecutar_simulacion(max_autobuses=numero_autobuses)
+    modelo.VERBOSE = anterior
+    tiempo_total = estacion.tiempo_espera_total + numero_autobuses * TIEMPO_REEMPLAZO
+    return tiempo_total / numero_autobuses
+
+def main():
+    max_autos = param_simulacion.max_autobuses
+    valores = list(range(1, max_autos + 1))
+    tiempos = [tiempo_promedio_para_autobuses(n) for n in valores]
+
+    plt.figure(figsize=(8, 4))
+    plt.plot(valores, tiempos, marker='o')
+    plt.xlabel('Número de autobuses')
+    plt.ylabel('Tiempo promedio de intercambio (horas)')
+    plt.title('Promedio de intercambio según cantidad de autobuses')
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- make modelo reusable by guarding main logic
- add VERBOSE toggle to reduce logging
- add `ejecutar_simulacion` for programmatic runs
- provide new script `tiempos_intercambio.py` that plots average swap time vs bus count
- document how to run the new plot in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850fca19fd88330a6f96d16d1468cd3