### PR TITLE
Add queue-aware swap time plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 Este repositorio contiene utilidades para simulación.
 
+## Gráfico de tiempo de intercambio
+
+Ejecuta el script `tiempos_intercambio.py` para generar un gráfico que muestra
+el tiempo promedio de intercambio según cuántos autobuses llegan a la estación.
+Cada intercambio dura 4 minutos más el tiempo de espera de los autobuses cuando
+las estaciones de carga están ocupadas. El script agrupa a todos los autobuses
+de la simulación para reflejar esta cola:
+
+```bash
+python tiempos_intercambio.py
+```
+
+Se abrirá una ventana con la gráfica correspondiente.
+
 ## Ejecutar las pruebas
 
 Instala `pytest` y ejecuta las pruebas con:

--- a/parametros/economicos.py
+++ b/parametros/economicos.py
@@ -1,19 +1,19 @@
 class ParametrosEconomicos:
     """Parámetros económicos que pueden modificarse."""
 
-    def __init__(self, costo_punta=0.28, costo_normal=0.238, costo_petroleo_completo=300, horas_punta=(18, 23)):
+    def __init__(self, costo_punta=0.28, costo_normal=0.238, costo_gas_completo=300, horas_punta=(18, 23)):
         self.costo_punta = costo_punta
         self.costo_normal = costo_normal
-        self.costo_petroleo_completo = costo_petroleo_completo
+        self.costo_gas_completo = costo_gas_completo
         self.horas_punta = horas_punta
 
-    def actualizar(self, punta=None, normal=None, petroleo=None, horas=None):
+    def actualizar(self, punta=None, normal=None, gas=None, horas=None):
         """Actualiza los costos o las horas punta."""
         if punta is not None:
             self.costo_punta = punta
         if normal is not None:
             self.costo_normal = normal
-        if petroleo is not None:
-            self.costo_petroleo_completo = petroleo
+        if gas is not None:
+            self.costo_gas_completo = gas
         if horas is not None:
             self.horas_punta = horas

--- a/parametros/simulacion.py
+++ b/parametros/simulacion.py
@@ -1,7 +1,7 @@
 class ParametrosSimulacion:
     """Parámetros generales de la simulación."""
 
-    def __init__(self, duracion=50, max_autobuses=20, semilla=42):
+    def __init__(self, duracion=50, max_autobuses=30, semilla=42):
         self.duracion = duracion
         self.max_autobuses = max_autobuses
         self.semilla = semilla

--- a/tiempos_intercambio.py
+++ b/tiempos_intercambio.py
@@ -1,0 +1,37 @@
+import matplotlib.pyplot as plt
+
+import modelo
+
+from modelo import param_simulacion
+
+TIEMPO_REEMPLAZO = 4 / 60  # Tiempo fijo del intercambio en horas
+
+def tiempo_promedio_para_autobuses(numero_autobuses):
+    """Ejecuta la simulación para cierto número de autobuses y devuelve
+    el tiempo promedio de intercambio."""
+    # Desactivar la verbosidad durante las simulaciones
+    anterior = modelo.VERBOSE
+    modelo.VERBOSE = False
+    estacion = modelo.ejecutar_simulacion(
+        max_autobuses=numero_autobuses, intervalo_llegada=0
+    )
+    modelo.VERBOSE = anterior
+    tiempo_total = estacion.tiempo_espera_total + numero_autobuses * TIEMPO_REEMPLAZO
+    return tiempo_total / numero_autobuses
+
+def main():
+    max_autos = param_simulacion.max_autobuses
+    valores = list(range(1, max_autos + 1))
+    tiempos = [tiempo_promedio_para_autobuses(n) for n in valores]
+
+    plt.figure(figsize=(8, 4))
+    plt.plot(valores, tiempos, marker='o')
+    plt.xlabel('Número de autobuses')
+    plt.ylabel('Tiempo promedio de intercambio (horas)')
+    plt.title('Promedio de intercambio según cantidad de autobuses')
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- explain queueing behavior in README
- allow custom arrival rate in `modelo.ejecutar_simulacion`
- cut swap time to 4 minutes and expose arrival interval to plot
- update `tiempos_intercambio.py` to launch buses simultaneously
- switch to natural gas costs and shorter 10-min wait checks
- default to 30 buses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6850fca19fd88330a6f96d16d1468cd3