### PR TITLE
Fix station resource usage

### DIFF
--- a/modelo.py
+++ b/modelo.py
@@ -36,7 +36,12 @@ def calcular_soc_inicial(hora_actual):
 class EstacionIntercambio:
     def __init__(self, env, capacidad_estacion):
         self.env = env
+        # Recursos separados para intercambios y cargadores
+        # "estaciones" representa los puntos donde los autobuses realizan el
+        # cambio de batería, mientras que "cargadores" son los conectores que
+        # recargan las baterías descargadas.
         self.estaciones = simpy.Resource(env, capacity=capacidad_estacion)
+        self.cargadores = simpy.Resource(env, capacity=capacidad_estacion)
         self.baterias_disponibles = param_estacion.baterias_iniciales  # Baterías cargadas listas
         # Baterías descargadas a la espera de carga
         self.baterias_descargadas = param_estacion.total_baterias - param_estacion.baterias_iniciales
@@ -106,7 +111,8 @@ class EstacionIntercambio:
                 self.baterias_disponibles + self.baterias_cargando
                 < param_estacion.total_baterias
             ):
-                with self.estaciones.request() as req:
+                # Utiliza un cargador disponible para recargar la batería
+                with self.cargadores.request() as req:
                     yield req
                     self.baterias_descargadas -= 1
                     self.baterias_cargando += 1

--- a/tiempos_intercambio.py
+++ b/tiempos_intercambio.py
@@ -1,7 +1,4 @@
-import matplotlib.pyplot as plt
-
 import modelo
-
 from modelo import param_simulacion
 
 TIEMPO_REEMPLAZO = 4 / 60  # Tiempo fijo del intercambio en horas
@@ -22,6 +19,11 @@ def tiempo_promedio_para_autobuses(numero_autobuses):
     return (tiempo_total / estacion.intercambios_realizados) * 60
 
 def main():
+    # Importar matplotlib solo cuando se ejecuta directamente para
+    # evitar dependencias innecesarias al utilizar este módulo desde
+    # otros scripts o durante las pruebas.
+    import matplotlib.pyplot as plt
+
     max_autos = param_simulacion.max_autobuses
     valores = list(range(1, max_autos + 1))
     tiempos = [tiempo_promedio_para_autobuses(n) for n in valores]


### PR DESCRIPTION
## Summary
- separate charger and swap resources in the simulation model
- allow importing `tiempos_intercambio` without matplotlib installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68513b4e1b4c8330803debc384c66722